### PR TITLE
Aliases for json fields with type other than string

### DIFF
--- a/src/main/scala/org/imagination/comparator/JsonComparator.scala
+++ b/src/main/scala/org/imagination/comparator/JsonComparator.scala
@@ -12,28 +12,29 @@ case class JsonComparator(mode:Mode = Strict)(implicit alias:Alias = AliasMap())
 
   @throws[MatchException]
   override def compare(expected: JsonNode, actual: JsonNode) {
-    raise(expected.getNodeType != actual.getNodeType,
-      s"Expected ${expected.getNodeType} but was ${actual.getNodeType}")
-
-    (expected.getNodeType: @unchecked) match {
-      case BOOLEAN =>
+    (expected.getNodeType, actual.getNodeType) match {
+      case (BOOLEAN, BOOLEAN) =>
         raise(expected.asBoolean() != actual.asBoolean(),
           s"Property ${expected.asText()} is not equal to ${actual.asText()}")
 
-      case NUMBER =>
+      case (NUMBER, NUMBER) =>
         raise(expected.asDouble() != actual.asDouble(),
           s"Property ${expected.asText()} is not equal to ${actual.asText()}")
 
-      case STRING =>
+      case (STRING, _) =>
         StringComparator(mode).compare(expected.asText(), actual.asText())
 
-      case ARRAY =>
+      case (ARRAY, ARRAY) =>
         compareElements(expected.elements().toList, actual.elements().toList)
 
-      case OBJECT =>
+      case (OBJECT, OBJECT) =>
         compareFields(expected.fields().toList, actual.fields().toList)
 
-      case NULL => // equals
+      case (NULL, NULL) => // equals
+
+      case _ =>
+        raise(expected.getNodeType != actual.getNodeType,
+          s"Expected ${expected.getNodeType} but was ${actual.getNodeType}")
     }
   }
 

--- a/src/test/fs/json/strict/ok/1/actual.json
+++ b/src/test/fs/json/strict/ok/1/actual.json
@@ -20,6 +20,7 @@
     "expiration_date" : "",
     "planned_space" : 100,
     "monthly_charge" : 2000.50,
-    "overused_charge" : 50.99
+    "overused_charge" : 50.99,
+    "version": 1468620756554
   }
 }

--- a/src/test/fs/json/strict/ok/1/expected.json
+++ b/src/test/fs/json/strict/ok/1/expected.json
@@ -20,6 +20,7 @@
     "expiration_date" : "",
     "planned_space" : 100,
     "monthly_charge" : 2000.50,
-    "overused_charge" : 50.99
+    "overused_charge" : 50.99,
+    "version": "p(>=0)"
   }
 }


### PR DESCRIPTION
Currently it's not possible to set alias for properties with type other than string, this PR addresses this:
expected:
```json
{
 "version": "p(>=0)"
}
```

actual:
```json
{
 "version": 1234567
}
```